### PR TITLE
added await  in exception-handler.middleware.ts

### DIFF
--- a/src/server/exception-handler.middleware.ts
+++ b/src/server/exception-handler.middleware.ts
@@ -2,7 +2,7 @@ import {Exception} from "../common/exception";
 
 export default async (ctx, next) => {
     try {
-        return next();
+        return await next();
     } catch (err) {
         if (err instanceof Exception) {
             // it transform the exception to an object literal


### PR DESCRIPTION
Due to lack of await, there is no catch exception in the catch block
